### PR TITLE
Fix for rust 1.0.0-alpha2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ This is a proof of concept Pebble application written in Rust (http://rust-lang.
 
 rusty.rs contains the app itself. pebblerust contains a rust version of the pebble library.
 
+Prerequisites
+-------------
+
+Make sure you a recent version of Rust (1.0-beta).
+
+    brew tap caskroom/cask
+    brew install brew-cask
+    brew tap caskroom/versions
+    brew cask install rust-nightly
+
+Rust has forked LLVM and is loosely based on LLVM 3.6 which isn't released yet.
+In LLVM 3.5 you might get weird `error: expected type` messages.
+
+You can try to build Rust's custom LLVM yourself.
+
+    git clone --depth 1 -b rust-llvm-2015-02-19 https://github.com/rust-lang/llvm
+    (cd llvm && ./configure --enable-optimized && make)
+
 Building & Installing
 ---------------------
 In order to build it, you will need installed on your system:
@@ -14,6 +32,7 @@ In order to build it, you will need installed on your system:
 * A recent rust compiler (0.12 works fine as of this writing).
 
 Otherwise, you can build & install it just like you would any pebble app
-  $ pebble build
-  $ pebble install
+
+    pebble build
+    pebble install
 

--- a/appinfo.json
+++ b/appinfo.json
@@ -4,7 +4,7 @@
   "longName": "Rusty",
   "companyName": "Pebble",
   "versionCode": 1,
-  "versionLabel": "1.0.0",
+  "versionLabel": "1.0",
   "watchapp": {
     "watchface": false
   },

--- a/lib/thumbv7m-none-eabi.json
+++ b/lib/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../thumbv7m-none-eabi.json

--- a/src/pebblerust/c.rs
+++ b/src/pebblerust/c.rs
@@ -1,8 +1,9 @@
-use pebblerust::types::*; 
+use pebblerust::types::*;
 extern {
   pub fn app_event_loop();
   pub fn window_create() -> *mut Window;
   pub fn window_stack_push(window: *mut Window, animated: bool);
+  pub fn window_stack_pop_all();
   pub fn app_log(level: u8, filename: *const u8, line_num: u32, msg: *const u8);
   pub fn window_set_click_config_provider(window: *mut Window, provider: extern fn(*mut u8));
   pub fn window_set_click_config_provider_with_context(window: *mut Window, provider: extern fn(*mut u8), context: *mut u8);

--- a/src/pebblerust/lib.rs
+++ b/src/pebblerust/lib.rs
@@ -3,11 +3,11 @@ use pebblerust::types::*;
 use pebblerust::c;
 
 pub enum AppLogLevel {
-  AppLogLevelError = 1,
-  AppLogLevelWarning = 50,
-  AppLogLevelInfo = 100,
-  AppLogLevelDebug = 200,
-  AppLogLevelDebugVerbose = 255,
+  Error = 1,
+  Warning = 50,
+  Info = 100,
+  Debug = 200,
+  DebugVerbose = 255,
 }
 
 pub fn app_event_loop() {

--- a/src/pebblerust/zero.rs
+++ b/src/pebblerust/zero.rs
@@ -14,7 +14,7 @@
 #![feature(intrinsics)]
 
 extern { fn puts(s: *const u8); }
-extern "rust-intrinsic" { fn transmute<T, U>(t: T) -> U; }
+extern "rust-intrinsic" { pub fn transmute<T, U>(t: T) -> U; }
 
 #[lang = "stack_exhausted"] extern fn stack_exhausted() {}
 #[lang = "eh_personality"] extern fn eh_personality() {}

--- a/src/pebblerust/zero.rs
+++ b/src/pebblerust/zero.rs
@@ -1,35 +1,28 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Copied from
+// https://github.com/rust-lang/rust/blob/master/src/test/run-pass/smallest-hello-world.rs
+
 #![feature(intrinsics)]
 
-extern crate core;
+extern { fn puts(s: *const u8); }
+extern "rust-intrinsic" { fn transmute<T, U>(t: T) -> U; }
 
-use pebblerust::c;
+#[lang = "stack_exhausted"] extern fn stack_exhausted() {}
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
 
-extern "rust-intrinsic" {
-    pub fn transmute<T,U>(val: T) -> U;
-}
-
-#[lang="stack_exhausted"] extern fn stack_exhausted() {}
-
-#[lang="eh_personality"] extern fn eh_personality() {}
-
-#[lang="panic_fmt"]
-pub fn panic_fmt(_fmt: &core::fmt::Arguments, _file_line: &(&'static str, usize)) -> ! {
-  // TODO: logging
-
-  unsafe {
-    c::window_stack_pop_all();
-  }
-
-  loop {}
-}
+// Additions
 
 // If we don't implement this here the linker will link against libunwind
 // which will then require kill, getpid()... which isn't available.
 #[no_mangle]
-pub unsafe fn __aeabi_unwind_cpp_pr0() -> () {
-  unsafe {
-    c::window_stack_pop_all();
-  }
-
-  loop {}
-}
+pub unsafe fn __aeabi_unwind_cpp_pr0() -> () { loop {} }

--- a/src/pebblerust/zero.rs
+++ b/src/pebblerust/zero.rs
@@ -1,4 +1,35 @@
+#![feature(intrinsics)]
+
+extern crate core;
+
+use pebblerust::c;
+
 extern "rust-intrinsic" {
     pub fn transmute<T,U>(val: T) -> U;
 }
 
+#[lang="stack_exhausted"] extern fn stack_exhausted() {}
+
+#[lang="eh_personality"] extern fn eh_personality() {}
+
+#[lang="panic_fmt"]
+pub fn panic_fmt(_fmt: &core::fmt::Arguments, _file_line: &(&'static str, usize)) -> ! {
+  // TODO: logging
+
+  unsafe {
+    c::window_stack_pop_all();
+  }
+
+  loop {}
+}
+
+// If we don't implement this here the linker will link against libunwind
+// which will then require kill, getpid()... which isn't available.
+#[no_mangle]
+pub unsafe fn __aeabi_unwind_cpp_pr0() -> () {
+  unsafe {
+    c::window_stack_pop_all();
+  }
+
+  loop {}
+}

--- a/src/rusty.rs
+++ b/src/rusty.rs
@@ -1,8 +1,10 @@
-#![crate_type="lib"]
-#![no_std]
-#![feature(globs)]
+#![feature(no_std)]
 #![feature(lang_items)]
 #![feature(intrinsics)]
+#![feature(core)]
+#![feature(int_uint)]
+#![crate_type="staticlib"]
+#![no_std]
 
 extern crate core;
 
@@ -35,7 +37,7 @@ extern fn click_config_provider(_: *mut TextLayer) {
 }
 
 extern fn window_load_handler(window: *mut Window) {
-  app_log(AppLogLevelDebug, "window loaded!\0");
+  app_log(AppLogLevel::Debug, "window loaded!\0");
   let window_layer = window_get_root_layer(window);
   let window_bounds = layer_get_bounds(window_layer);
 
@@ -59,8 +61,9 @@ extern fn window_disappear_handler(window: *mut Window) {
 }
 
 #[no_mangle]
+#[no_stack_check]
 pub extern fn main() -> int {
-  app_log(AppLogLevelDebug, "Pebble-y Rust, Rust-y Pebble\0");
+  app_log(AppLogLevel::Debug, "Pebble-y Rust, Rust-y Pebble\0");
   let window = window_create();
   let window_handlers = WindowHandlers {
     load: window_load_handler,

--- a/thumbv7m-none-eabi.json
+++ b/thumbv7m-none-eabi.json
@@ -1,0 +1,13 @@
+{
+    "arch": "arm",
+    "cpu": "cortex-m3",
+    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "disable-redzone": true,
+    "executables": true,
+    "llvm-target": "thumbv7m-none-eabi",
+    "morestack": false,
+    "os": "none",
+    "relocation-model": "static",
+    "target-endian": "little",
+    "target-pointer-width": "32"
+}

--- a/wscript
+++ b/wscript
@@ -5,6 +5,7 @@
 # Feel free to customize this to your needs.
 #
 
+import shutil
 from waflib import Task, TaskGen
 from waflib.TaskGen import extension
 
@@ -13,7 +14,7 @@ out = 'build'
 
 TaskGen.declare_chain(
     name='rustc',
-    rule='${RUSTC} -L ../lib/ --target arm-linux-eabi ${SRC} --emit=ir -A dead-code -o ${TGT}',
+    rule='${RUSTC} -L ../lib/ -C target-cpu=cortex-m3 --target thumbv7m-none-eabi ${SRC} --emit=llvm-ir -A dead-code -o ${TGT}',
     ext_in='.rs',
     ext_out='.ll',)
 
@@ -39,9 +40,11 @@ def build(ctx):
     ctx.env.RUSTC = 'rustc'
     ctx.env.LLC = '/usr/local/opt/llvm/bin/llc'
 
+    shutil.copy2('thumbv7m-none-eabi.json', out)
+
     ctx.load('pebble_sdk')
 
-    ctx.pbl_program(source=ctx.path.ant_glob('src/*.(rs|c|o)'),
+    ctx.pbl_program(source=ctx.path.ant_glob('src/*.(rs|c)'),
                     target='pebble-app.elf')
 
     ctx.pbl_bundle(elf='pebble-app.elf',

--- a/wscript
+++ b/wscript
@@ -14,7 +14,7 @@ out = 'build'
 
 TaskGen.declare_chain(
     name='rustc',
-    rule='${RUSTC} -L ../lib/ -C target-cpu=cortex-m3 --target thumbv7m-none-eabi ${SRC} --emit=llvm-ir -A dead-code -o ${TGT}',
+    rule='${RUSTC} -L ../lib/ -C target-cpu=cortex-m3 --target thumbv7m-none-eabi ${SRC} --emit=llvm-ir -o ${TGT}',
     ext_in='.rs',
     ext_out='.ll',)
 
@@ -38,7 +38,7 @@ def configure(ctx):
 
 def build(ctx):
     ctx.env.RUSTC = 'rustc'
-    ctx.env.LLC = '/usr/local/opt/llvm/bin/llc'
+    ctx.env.LLC = '../lib/llvm/Debug+Asserts/bin/llc'
 
     shutil.copy2('thumbv7m-none-eabi.json', out)
 


### PR DESCRIPTION
Hey François,

I just wanted to test using Rust on my Pebble and wasn't surprised to find out that it didn't work (with Rust changing so much). I upgraded everything to work with the latest version (Version 1.0.0-alpha.2 (February 2015)). Let's hope that their API remains more stable until the official 1.0 release.

There is one issue with `llc` not being able to parse the IR output from Rust. This seems to be caused by Rust using a forked LLVM (seems to be loosely based on LLVM 3.6 which should come out next month). I added a note on that in the README.

Enjoy your weekend!
Marcel
